### PR TITLE
Use close builtin instead of method call on a filehandle.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module Lingua::Stem::Ru
 
+0.04_02 2016-03-10 ZORAN
+    - Fixed t/02-stem.t: replaced close method call on a filehandle with close builtin.
+
 0.04_01 2016-03-08 NEILB
     - Split original test into multiple tests, and use Test::More
     - Fixed doc s/Lingua::Stemmer::Ru/Lingua::Stem::Ru/g

--- a/dist.ini
+++ b/dist.ini
@@ -4,7 +4,7 @@ license = Perl_5
 copyright_holder = Aleksandr Guidrevitch
 copyright_year   = 2004
 
-version = 0.04_01
+version = 0.04_02
 
 [@Filter]
 -bundle = @Basic

--- a/t/02-stem.t
+++ b/t/02-stem.t
@@ -16,7 +16,7 @@ sub words_from_file {
 	my ($file) = @_;
 	open (my $fh,'<',$file) or die($!);
 	my @rows = map {chomp; $_} <$fh>;
-	$fh->close();
+	close($fh);
 	return @rows;
 }
 


### PR DESCRIPTION
This fixes test failures on perl v5.12 and lower.

Thank you CPAN Testers! :-)
